### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,20 @@
 repos:
-- repo: local
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
   hooks:
-    - id: pylint
-      name: pylint
-      entry: pylint
-      language: system
-      types: [python]
-      args:
-        [
-          "--rcfile=pylintrc",
-        ]
+  - id: flake8
 - repo: https://github.com/ambv/black
   rev: 21.1.0
   hooks:
   - id: black
     language_version: python3.8
+- repo: https://github.com/ambv/black
+  rev: 21.1.0
+  hooks:
+  - id: black
+    language_version: python3.8
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: local
+  hooks:
+    - id: pylint
+      name: pylint
+      entry: pylint
+      language: system
+      types: [python]
+      args:
+        [
+          "--rcfile=pylintrc",
+        ]
+- repo: https://github.com/ambv/black
+  rev: 21.1.0
+  hooks:
+  - id: black
+    language_version: python3.8


### PR DESCRIPTION
Add pre-commit configuration (can be installed via `pre-commit install`) to make sure all commits follow the style guidelines.