### PR TITLE
[Website] Fix broken links

### DIFF
--- a/docs/source/call_for_papers.rst
+++ b/docs/source/call_for_papers.rst
@@ -31,8 +31,8 @@ Submissions creating links to communities interested in problems besides standar
 are very welcome.
 
 For general questions about preparations of submissions, clarifications around the submission score and 
-discussions about the ``shifthappens`` API, please feel free to write us as [shifthappens@bethgelab.org](mailto:shifthappens@bethgelab.org)
-or [join our slack channel](https://join.slack.com/t/shifthappensicml2022/shared_invite/zt-16ewcukds-6jW6xC5DbtRvLCCkhZ~NLg).
+discussions about the ``shifthappens`` API, please feel free to write us as `shifthappens@bethgelab.org <mailto:shifthappens@bethgelab.org>`__
+or `join our slack channel <https://join.slack.com/t/shifthappensicml2022/shared_invite/zt-16ewcukds-6jW6xC5DbtRvLCCkhZ~NLg>`__.
 
 Deadlines
 ^^^^^^^^^^^^^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,8 +74,8 @@ Please see our :doc:`call_for_papers` for more details.
 
 
 For general questions about preparations of submissions, clarifications around the submission score and 
-discussions about the ``shifthappens`` API, please feel free to write us as [shifthappens@bethgelab.org](mailto:shifthappens@bethgelab.org)
-or [join our slack channel](https://join.slack.com/t/shifthappensicml2022/shared_invite/zt-16ewcukds-6jW6xC5DbtRvLCCkhZ~NLg).
+discussions about the ``shifthappens`` API, please feel free to write us as `shifthappens@bethgelab.org <mailto:shifthappens@bethgelab.org>`__
+or `join our slack channel <https://join.slack.com/t/shifthappensicml2022/shared_invite/zt-16ewcukds-6jW6xC5DbtRvLCCkhZ~NLg>`__.
 
 Important Deadlines
 -------------------


### PR DESCRIPTION
This PR corrects some of the links that were added (accidentially) as Markdown-style and not the sphinx-compatible reStructredText-style.