### PR TITLE
Extend API documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -33,12 +33,10 @@ Model implementations
 .. automodule:: shifthappens.models.base
    :members:
    :show-inheritance:
-   :noindex:
 
 .. automodule:: shifthappens.models.torchvision
    :members:
    :show-inheritance:
-   :noindex:
 
 
 Task implementations
@@ -47,6 +45,15 @@ Task implementations
 .. automodule:: shifthappens.tasks.base
    :members:
    :show-inheritance:
-   :noindex:
    :private-members:
+
+Data loading
+------------
+.. automodule:: shifthappens.data.base
+   :members:
+   :show-inheritance:
+
+.. automodule:: shifthappens.data.torch
+   :members:
+   :show-inheritance:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,37 +6,28 @@
 Welcome to the API docs of the ShiftHappens benchmark!
 ======================================================
 
-.. note::
-
-    We are working on writing and extending the documentation for the API and on creating helper functions and classes to make the user experience more convenient.
-
-**We aim to create a community-built benchmark suite for ImageNet models comprised of new datasets for OOD robustness
-and detection, as well as new tasks for existing OOD datasets.**
-
+We aim to create a community-built benchmark suite for ImageNet models comprised of new datasets for OOD robustness
+and detection, as well as new tasks for existing OOD datasets.
 
 While the popularity of robustness benchmarks and new test datasets
 increased over the past years, the performance of computer vision models
 is still largely evaluated on ImageNet directly, or on simulated or
 isolated distribution shifts like in ImageNet-C. 
 
-**Motivation:** The goal of this workshop is to enhance the landscape of robustness evaluation datasets for
+The goal of this workshop is to enhance the landscape of robustness evaluation datasets for
 computer vision and devise new test sets and metrics for quantifying desirable 
 properties of computer vision models. Our goal is to bring the robustness, domain
 adaptation, and out-of-distribution detection communities together to work on a new
 **broad-scale benchmark** that tests diverse aspects of current computer
 vision models and guides the way towards the next generation of models.
 
+Submissions to the workshop will be comprised of an addition of a ``Task``, which will be used to test the performance 
+of various computer vision models on a new evaluation task you specify with your submission. Below we provide documentation
+for the ``shifthappens`` API.
 
-Model implementations
----------------------
-
-.. automodule:: shifthappens.models.base
-   :members:
-   :show-inheritance:
-
-.. automodule:: shifthappens.models.torchvision
-   :members:
-   :show-inheritance:
+Also make sure to look at the `examples <https://github.com/shift-happens-benchmark/icml-2022/tree/main/examples>`_
+in the github repository. If in doubt or if the API is not yet sufficiently flexible to fit your needs, consider
+opening an issue on github or join our slack channel.
 
 
 Task implementations
@@ -57,3 +48,9 @@ Data loading
    :members:
    :show-inheritance:
 
+Model implementations
+---------------------
+
+.. automodule:: shifthappens.models.base
+   :members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,15 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
 ]
+
+intersphinx_mapping = {
+    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    "python": ("https://docs.python.org/3", None),
+}
+
+# napoleon_use_param = True
 
 coverage_show_missing_items = True
 
@@ -57,6 +65,11 @@ copybutton_prompt_text = r">>> |\$ "
 copybutton_prompt_is_regexp = True
 copybutton_only_copy_prompt_lines = True
 autodoc_member_order = "bysource"
+
+typehints_defaults = "comma"
+always_document_param_types = True
+simplify_optional_unions = True
+
 
 templates_path = ["_templates"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,3 +125,5 @@ html_scaled_image_link = False
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
+
+add_function_parentheses = False

--- a/shifthappens/models/base.py
+++ b/shifthappens/models/base.py
@@ -1,11 +1,11 @@
 """Base classes and helper functions for adding models to the benchmark.
 
 To add a new model, implement a new wrapper class inheriting from
-``shifthappens.base.Model``, and from any of the Mixins defined
+:py:class:`shifthappens.models.base.Model`, and from any of the Mixins defined
 in this module.
 
-Model results should be converted to numpy arrays, and packed into an
-``shifthappens.base.ModelResult`` instance.
+Model results should be converted to :py:class:`numpy.ndarray` objects, and packed into an
+:py:class:`shifthappens.models.base.ModelResult` instance.
 """
 
 import abc
@@ -25,21 +25,21 @@ class ModelResult:
     regarding the ordering of labels.
 
     Args:
-        class_labels: ``(N, k)`` array containing top-k predictions for
+        class_labels: ``(N, k)``, top-k predictions for
             each sample in the batch. Choice of ``k`` can be selected by
             the user, and potentially influences the type of accuracy
             based benchmarks that the model can be run on. For standard
             ImageNet, ImageNet-C evaluation, choose at least ``k=5``.
-        confidences: optional, ``(N, 1000)`` confidences for each class.
+        confidences: ``(N, 1000)``, confidences for each class.
             Standard PyTorch ImageNet class label order is expected for
             this array. Scores can be in the range ``-inf`` to ``inf``.
-        uncertainties: optional, ``(N, 1000)``, uncertainties for the
+        uncertainties: ``(N, 1000)``, uncertainties for the
             different class predictions. Different from the ``confidences``,
             this is a measure of certainty of the given ``confidences`` and
             common e.g. in Bayesian Deep neural networks.
-        ood_scores: optional, ``(N,)``, score for interpreting the sample
+        ood_scores: ``(N,)``, score for interpreting the sample
             as an out-of-distribution class, in the range ``-inf`` to ``inf``.
-        features: optional, ``(N, d)``, where ``d`` can be arbitrary, feature
+        features: ``(N, d)``, where ``d`` can be arbitrary, feature
             representation used to arrive at the given predictions.
     """
 

--- a/shifthappens/models/torchvision.py
+++ b/shifthappens/models/torchvision.py
@@ -1,4 +1,5 @@
 """Torchvision baselines."""
+
 from typing import Iterator
 from typing import List
 

--- a/shifthappens/tasks/base.py
+++ b/shifthappens/tasks/base.py
@@ -1,4 +1,21 @@
-"""Base definition of a task in the shift happens benchmark."""
+"""Base definition of a task in the shift happens benchmark.
+
+Fully defined tasks should subclass the ``Task`` abstract base class, and implement all
+mixins based on the required model outputs to evaluate the task, also part of this module.
+
+Implementing a new task consists of the following steps:
+
+1. Subclass the ``Task`` class and implement its abstract methods to specify the task
+   setup and evaluation scheme
+2. Implement any number of mixins specified in this module. You just need to include
+   the mixin in the class definition, e.g. ``class MyTask(Task, ConfidenceTaskMixin)``,
+   and do not need to implement additional methods. My specifying the mixin, it will be
+   assured that your task gets the correct model outputs.
+   See the individual mixin classes, or the ``shifthappens.models.models.base.ModelResult``
+   class for further details.
+3. Register your class to the benchmark using the ``shifthappens.benchmark.register_task``
+   decorator, along with a name and data path for your benchmark. 
+"""
 
 import dataclasses
 from abc import ABC
@@ -61,7 +78,15 @@ def abstract_variable():
 
 @dataclasses.dataclass  # type: ignore
 class Task(ABC):
-    """Task base class."""
+    """Task base class.
+
+    Override the ``setup``, ``_prepare_dataloader`` and ``_evaluate`` methods to define
+    your task. Also make sure to add in additional mixins from ``shifthappens.tasks.mixins`` to specify
+    which models your task is compatible to (e.g., specify that your task needs labels, or confidences from
+    a model).
+
+    To include the task in the benchmark, use the ``shifthappens.benchmark.register_task`` decorator.
+    """
 
     data_root: str
 
@@ -151,42 +176,79 @@ class Task(ABC):
 
     @abstractmethod
     def _prepare_dataloader(self) -> Optional[DataLoader]:
-        """Prepares a dataloader for just the images (i.e. no labels, etc.) which will be passed to the model
-        before the actual evaluation. This allows models to, e.g., run unsupervised domain adaptation techniques."""
+        """Prepare a dataloader for just the images (i.e. no labels, etc.) which will be passed to the model
+        before the actual evaluation. This allows models to, e.g., run unsupervised domain adaptation techniques.
+
+        If intended, the implementation of this function should call the ``shifthappens.models.model.Model.prepare``
+        function and pass (parts) of the data through a data loader. The model could potentially use this data for
+        test-time adaptation, calibration, or orther purposes.
+
+        Note that this function could also be used to create domain shift for such adaptation methods, by passing
+        a different dataloader in this prepare function than used during ``evaluate()``.
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def _evaluate(self, model: sh_models.Model) -> TaskResult:
-        """Implement this function to evaluate the task and return a dictionary with the
-        calculated metrics."""
+        """Evaluate the task and return a dictionary with the calculated metrics.
+
+        model: The passed model implementents a ``predict`` function returning an iterator
+        over ``shifthappens.models.base.ModelResult``. Each result contains predictions such as
+        the class labels assigned to the images, confidences, etc., based on which mixins were
+        implemented by this task to request these prediction outputs.
+
+        This function should return a ``shifthappens.tasks.task_result.TaskResult`` which can
+        contain an arbitrary dictionary of metrics, along with a specifiction of which of these
+        metrics are main results/summary metrics for the task.
+        """
         raise NotImplementedError()
 
 
 class LabelTaskMixin:
-    """Indicates that the task requires the model to return the predicted labels."""
+    """Indicates that the task requires the model to return the predicted labels.
+
+    Tasks implementing this mixin will be provided with the ``class_labels`` attribute in the
+    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    """
 
     pass
 
 
 class ConfidenceTaskMixin:
-    """Indicates that the task requires the model to return the confidence scores."""
+    """Indicates that the task requires the model to return the confidence scores.
+
+    Tasks implementing this mixin will be provided with the ``confidences`` attribute in the
+    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    """
 
     pass
 
 
 class UncertaintyTaskMixin:
-    """Indicates that the task requires the model to return the uncertainty scores."""
+    """Indicates that the task requires the model to return the uncertainty scores.
+
+    Tasks implementing this mixin will be provided with the ``uncertainties`` attribute in the
+    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    """
 
     pass
 
 
 class OODScoreTaskMixin:
-    """Indicates that the task requires the model to return the OOD scores."""
+    """Indicates that the task requires the model to return the OOD scores.
+
+    Tasks implementing this mixin will be provided with the ``ood_scores`` attribute in the
+    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    """
 
     pass
 
 
 class FeaturesTaskMixin:
-    """Indicates that the task requires the model to return the raw features."""
+    """Indicates that the task requires the model to return the raw features.
+
+    Tasks implementing this mixin will be provided with the ``features`` attribute in the
+    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    """
 
     pass

--- a/shifthappens/tasks/base.py
+++ b/shifthappens/tasks/base.py
@@ -1,19 +1,19 @@
 """Base definition of a task in the shift happens benchmark.
 
-Fully defined tasks should subclass the ``Task`` abstract base class, and implement all
+Fully defined tasks should subclass the :py:class:`Task` abstract base class, and implement all
 mixins based on the required model outputs to evaluate the task, also part of this module.
 
 Implementing a new task consists of the following steps:
 
-1. Subclass the ``Task`` class and implement its abstract methods to specify the task
+1. Subclass the :py:class:`Task` class and implement its abstract methods to specify the task
    setup and evaluation scheme
 2. Implement any number of mixins specified in this module. You just need to include
    the mixin in the class definition, e.g. ``class MyTask(Task, ConfidenceTaskMixin)``,
    and do not need to implement additional methods. My specifying the mixin, it will be
    assured that your task gets the correct model outputs.
-   See the individual mixin classes, or the ``shifthappens.models.models.base.ModelResult``
+   See the individual mixin classes, or the :py:class:`shifthappens.models.models.base.ModelResult`
    class for further details.
-3. Register your class to the benchmark using the ``shifthappens.benchmark.register_task``
+3. Register your class to the benchmark using the :py:func`shifthappens.benchmark.register_task`
    decorator, along with a name and data path for your benchmark. 
 """
 
@@ -80,12 +80,12 @@ def abstract_variable():
 class Task(ABC):
     """Task base class.
 
-    Override the ``setup``, ``_prepare_dataloader`` and ``_evaluate`` methods to define
-    your task. Also make sure to add in additional mixins from ``shifthappens.tasks.mixins`` to specify
+    Override the :py:meth:`setup`, :py:meth:`_prepare_dataloader` and :py:meth:`_evaluate` methods to define
+    your task. Also make sure to add in additional mixins from :py:mod:`shifthappens.tasks.base` to specify
     which models your task is compatible to (e.g., specify that your task needs labels, or confidences from
     a model).
 
-    To include the task in the benchmark, use the ``shifthappens.benchmark.register_task`` decorator.
+    To include the task in the benchmark, use the :py:func:`shifthappens.benchmark.register_task` decorator.
     """
 
     data_root: str
@@ -179,12 +179,12 @@ class Task(ABC):
         """Prepare a dataloader for just the images (i.e. no labels, etc.) which will be passed to the model
         before the actual evaluation. This allows models to, e.g., run unsupervised domain adaptation techniques.
 
-        If intended, the implementation of this function should call the ``shifthappens.models.model.Model.prepare``
+        If intended, the implementation of this function should call the :py:func:`shifthappens.models.model.Model.prepare`
         function and pass (parts) of the data through a data loader. The model could potentially use this data for
         test-time adaptation, calibration, or orther purposes.
 
         Note that this function could also be used to create domain shift for such adaptation methods, by passing
-        a different dataloader in this prepare function than used during ``evaluate()``.
+        a different dataloader in this prepare function than used during :py:meth:`evaluate`.
         """
         raise NotImplementedError()
 
@@ -193,11 +193,11 @@ class Task(ABC):
         """Evaluate the task and return a dictionary with the calculated metrics.
 
         model: The passed model implementents a ``predict`` function returning an iterator
-        over ``shifthappens.models.base.ModelResult``. Each result contains predictions such as
+        over :py:meth:`shifthappens.models.base.ModelResult`. Each result contains predictions such as
         the class labels assigned to the images, confidences, etc., based on which mixins were
         implemented by this task to request these prediction outputs.
 
-        This function should return a ``shifthappens.tasks.task_result.TaskResult`` which can
+        This function should return a :py:class:`shifthappens.tasks.task_result.TaskResult` which can
         contain an arbitrary dictionary of metrics, along with a specifiction of which of these
         metrics are main results/summary metrics for the task.
         """
@@ -208,7 +208,7 @@ class LabelTaskMixin:
     """Indicates that the task requires the model to return the predicted labels.
 
     Tasks implementing this mixin will be provided with the ``class_labels`` attribute in the
-    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    :py:class:`shifthappens.models.base.ModelResult` returned during evaluation.
     """
 
     pass
@@ -218,7 +218,7 @@ class ConfidenceTaskMixin:
     """Indicates that the task requires the model to return the confidence scores.
 
     Tasks implementing this mixin will be provided with the ``confidences`` attribute in the
-    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    :py:class:`shifthappens.models.base.ModelResult` returned during evaluation.
     """
 
     pass
@@ -228,7 +228,7 @@ class UncertaintyTaskMixin:
     """Indicates that the task requires the model to return the uncertainty scores.
 
     Tasks implementing this mixin will be provided with the ``uncertainties`` attribute in the
-    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    :py:class:`shifthappens.models.base.ModelResult` returned during evaluation.
     """
 
     pass
@@ -238,7 +238,7 @@ class OODScoreTaskMixin:
     """Indicates that the task requires the model to return the OOD scores.
 
     Tasks implementing this mixin will be provided with the ``ood_scores`` attribute in the
-    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    :py:class:`shifthappens.models.base.ModelResult` returned during evaluation.
     """
 
     pass
@@ -248,7 +248,7 @@ class FeaturesTaskMixin:
     """Indicates that the task requires the model to return the raw features.
 
     Tasks implementing this mixin will be provided with the ``features`` attribute in the
-    ``shifthappens.models.base.ModelResult`` returned during evaluation.
+    :py:class:`shifthappens.models.base.ModelResult` returned during evaluation.
     """
 
     pass

--- a/shifthappens/tasks/base.py
+++ b/shifthappens/tasks/base.py
@@ -192,14 +192,17 @@ class Task(ABC):
     def _evaluate(self, model: sh_models.Model) -> TaskResult:
         """Evaluate the task and return a dictionary with the calculated metrics.
 
-        model: The passed model implementents a ``predict`` function returning an iterator
-        over :py:meth:`shifthappens.models.base.ModelResult`. Each result contains predictions such as
-        the class labels assigned to the images, confidences, etc., based on which mixins were
-        implemented by this task to request these prediction outputs.
+        Args:
+            model: The passed model implementents a ``predict`` function returning an iterator
+            over :py:meth:`shifthappens.models.base.ModelResult`. Each result contains predictions such as
+            the class labels assigned to the images, confidences, etc., based on which mixins were
+            implemented by this task to request these prediction outputs.
 
-        This function should return a :py:class:`shifthappens.tasks.task_result.TaskResult` which can
-        contain an arbitrary dictionary of metrics, along with a specifiction of which of these
-        metrics are main results/summary metrics for the task.
+        Returns:
+            :py:class:`shifthappens.tasks.task_result.TaskResult`: The results of the task in the
+            form of a :py:class:`shifthappens.tasks.task_result.TaskResult` containing an 
+            arbitrary dictionary of metrics, along with a specifiction of which of these
+            metrics are main results/summary metrics for the task.
         """
         raise NotImplementedError()
 

--- a/shifthappens/tasks/base.py
+++ b/shifthappens/tasks/base.py
@@ -200,7 +200,7 @@ class Task(ABC):
 
         Returns:
             :py:class:`shifthappens.tasks.task_result.TaskResult`: The results of the task in the
-            form of a :py:class:`shifthappens.tasks.task_result.TaskResult` containing an 
+            form of a :py:class:`shifthappens.tasks.task_result.TaskResult` containing an
             arbitrary dictionary of metrics, along with a specifiction of which of these
             metrics are main results/summary metrics for the task.
         """


### PR DESCRIPTION
- Remove the duplicate "optional" classifiers currenlty in the text, this is done automatically by sphinx
- Remove the "temporary" note from `api.rst`
- Add more verbose descriptions to the task