### PR TITLE
Add list of accepted papers to website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,17 +11,23 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
+import datetime
 import os
 import sys
-from typing import List
 
+sys.path.insert(0, os.path.dirname(__file__))
 sys.path.insert(0, os.path.abspath("../.."))
 
-import datetime
+from typing import List
 
-import shifthappens
+try:
+    import render_papers
 
-autodoc_mock_imports = ["numpy", "torch", "torchvision"]
+    render_papers.main()
+except:
+    print("Did not update papers.rst")
+
+autodoc_mock_imports = ["numpy", "torch", "torchvision", "surgeon_pytorch"]
 
 
 def get_years(start_year=2021):
@@ -38,7 +44,7 @@ project = "Shift Happens (ICML 2022)"
 author = "Julian Bitterwolf, Evgenia Rusak, Steffen Schneider, Roland S. Zimmermann"
 
 copyright = f"{get_years(2021)}, {author} and contributors. Released under an Apache 2.0 License"
-release = shifthappens.__version__
+# release = shifthappens.__version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -125,6 +125,7 @@ Organizers
     Call for Submissions <call_for_papers>
     Call for Reviewers <call_for_reviewers>
     Benchmark API Docs <api>
+    Accepted Papers <papers>
 
 .. meta::
       :title: Shift happens 2022: Crowdsourcing metrics and test datasets beyond ImageNet

--- a/docs/source/papers.rst
+++ b/docs/source/papers.rst
@@ -1,0 +1,66 @@
+
+Accepted Papers
+===============
+
+
+Track 1: Benchmarks, Datasets and Metrics
+-----------------------------------------
+
+Contributed Talks
+~~~~~~~~~~~~~~~~~
+
+ImageNet-Patch: A Dataset for Benchmarking Machine Learning Robustness against Adversarial Patches.
+	Maura Pintor, Daniele Angioni, Angelo Sotgiu, Luca Demetrio, Ambra Demontis, Battista Biggio, Fabio Roli.
+
+MetaShift: A Dataset of Datasets for Evaluating Contextual Distribution Shifts.
+	Weixin Liang, Xinyu Yang, James Y. Zou.
+
+When does dough become a bagel?Analyzing the remaining mistakes on ImageNet.
+	Vijay Vasudevan, Benjamin Caine, Raphael Gontijo-Lopes, Sara Fridovich-Keil, Rebecca Roelofs.
+
+Posters
+~~~~~~~
+
+3D Common Corruptions for Object Recognition.
+	Oguzhan Fatih Kar, Teresa Yeo, Amir Zamir.
+
+CCC: Continuously Changing Corruptions.
+	Ori Press, Steffen Schneider, Matthias Kuemmerer, Matthias Bethge.
+
+Classifiers Should Do Well Even on Their Worst Classes.
+	Julian Bitterwolf, Alexander Meinke, Valentyn Boreiko, Matthias Hein.
+
+Evaluating Model Robustness to Patch Perturbations.
+	Jindong Gu, Volker Tresp, Yao Qin.
+
+ImageNet-Cartoon and ImageNet-Drawing: two domain shift datasets for ImageNet.
+	Tiago Salvador, Adam M Oberman.
+
+ImageNet-D: A new challenging robustness dataset inspired by domain adaptation.
+	Evgenia Rusak, Steffen Schneider, Peter Vincent Gehler, Oliver Bringmann, Wieland Brendel, Matthias Bethge.
+
+Lost in Translation: Modern Image Classifiers still degrade even under simple Translations.
+	Leander Kurscheidt, Matthias Hein.
+
+SI-Score.
+	Jessica Yung, Rob Romijnders, Alexander Kolesnikov, Lucas Beyer, Josip Djolonga, Neil Houlsby, Sylvain Gelly, Mario Lucic, Xiaohua Zhai.
+
+The Semantic Shift Benchmark.
+	Sagar Vaze, Kai Han, Andrea Vedaldi, Andrew Zisserman.
+
+Wild-Time: A Benchmark of in-the-Wild Distribution Shift over Time.
+	Huaxiu Yao, Caroline Choi, Yoonho Lee, Pang Wei Koh, Chelsea Finn.
+
+Track 2: Extended abstracts
+---------------------------
+
+Growing ObjectNet: Adding speech, VQA, occlusion, and measuring dataset difficulty.
+	David Mayo, David Lu, Chris Zhang, Jesse Cummings, Xinyu Lin, Boris Katz, James R. Glass, Andrei Barbu.
+
+OOD-CV: A Benchmark for Robustness to Individual Nuisances in Real-World Out-of-Distribution Shifts.
+	Bingchen Zhao, Shaozuo Yu, Wufei Ma, Mingxin Yu, Shenxiao Mei, Angtian Wang, Ju He, Alan Yuille, Adam Kortylewski.
+
+Towards Systematic Robustness for Scalable Visual Recognition.
+	Mohamed Omran, Bernt Schiele.
+
+

--- a/docs/source/render_papers.py
+++ b/docs/source/render_papers.py
@@ -1,0 +1,96 @@
+"""Create papers.rst file with accepted contributions."""
+
+import pathlib
+import textwrap
+
+import pandas as pd
+
+
+def format_for_website(line):
+    """Formatting function for pd.DataFrame.apply."""
+
+    full_submission = "Full submission" in str(
+        line.submission_type
+    ) or "Full submission" in str(line.track)
+    if full_submission:
+        if line.decision == "Accept (Contributed Talk)":
+            line["presentation_type"] = "talk"
+        elif line.decision == "Accept (Poster)":
+            line["presentation_type"] = "poster"
+        else:
+            raise ValueError(line.decision)
+        line["category"] = "full"
+    else:
+        line["presentation_type"] = "poster"
+        line["category"] = "abstract"
+
+    line["authors"] = line["authors"].replace("|", ", ")
+    line["formatted"] = "{title}.\n\t{authors}.".format(**line)
+    return line
+
+
+def filter_and_format(df, **kwargs):
+    for key, value in kwargs.items():
+        df = df[df[key] == value]
+    return "\n\n".join(df["formatted"].sort_values())
+
+
+def render_text(filename):
+
+    df = pd.read_csv(filename)
+    df = df[df.decision.apply(lambda v: "Accept" in v)]
+    df = df.apply(format_for_website, axis=1)
+
+    template = textwrap.dedent(
+        """
+  Accepted Papers
+  ===============
+  
+  
+  Track 1: Benchmarks, Datasets and Metrics
+  -----------------------------------------
+
+  Contributed Talks
+  ~~~~~~~~~~~~~~~~~
+
+  {talks}
+
+  Posters
+  ~~~~~~~
+
+  {posters}
+
+  Track 2: Extended abstracts
+  ---------------------------
+
+  {abstracts}
+
+  """
+    )
+
+    page = template.format(
+        talks=filter_and_format(df, category="full", presentation_type="talk"),
+        posters=filter_and_format(df, category="full", presentation_type="poster"),
+        abstracts=filter_and_format(df, category="abstract"),
+    )
+
+    with (pathlib.Path(__file__).parent / "papers.rst").open("w") as fh:
+        print(page, file=fh)
+
+
+def main():
+    # TODO(stes) pull data from OpenReview as soon as papers are public.
+    filename = pathlib.Path("/tmp/Shift_Happens_2022_paper_status.csv")
+    if filename.exists():
+        render_text(filename)
+    else:
+        print("Could not find the submission metadata. If you are a PC and want to")
+        print("update the website, please download the data from")
+        print(
+            "https://openreview.net/group?id=ICML.cc/2022/Workshop/Shift_Happens/Program_Chairs#paper-status"
+        )
+        print("and place the file under /tmp, then re-run.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Re-builds the page. If you want to test download [the paper list from OpenReview](https://openreview.net/group?id=ICML.cc/2022/Workshop/Shift_Happens/Program_Chairs#paper-status), place it in your `/tmp` dir and re-run `make docs`, which will update `papers.rst` in the repo.