### PR TITLE
[FIX] ResNet-18 accuracy 68.934 -> 69.752

### DIFF
--- a/shifthappens/models/torchvision.py
+++ b/shifthappens/models/torchvision.py
@@ -24,7 +24,7 @@ class __TorchvisionPreProcessingMixin:
         for item in batch:
             assert isinstance(item, np.ndarray)
             item_t = torch.tensor(item.transpose((2, 0, 1)))
-            item_t = tv_functional.resize(item_t, 256)
+            item_t = tv_functional.resize(item_t, 256, antialias=True)
             item_t = tv_functional.center_crop(item_t, 224)
             item_t = tv_functional.normalize(
                 item_t, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]


### PR DESCRIPTION
The problem was with resize step in the preprocessing. 

The problem is pretty much described in resize docs: "The output image might be different depending on its type: when downsampling, the interpolation of PIL images and tensors is slightly different, because PIL applies antialiasing. This may lead to significant differences in the performance of a network".

For ResNet-18, accuracy still slightly differs from https://pytorch.org/vision/stable/models.html. Our preprocessing pipeline (without PIL) achieves 69.752, when pytroch pipeline (with PIL) achieves 69.758.
