### PR TITLE
Update call for papers with camera ready submission template

### DIFF
--- a/docs/source/call_for_papers.rst
+++ b/docs/source/call_for_papers.rst
@@ -9,7 +9,7 @@ TL;DR
 ^^^^^
 
 We accept the following submission types: Full submissions and extended abstracts.
-A latex template (modified from the official ICML template) for **camera ready papers and extended abstracts** can be found `here <https://www.overleaf.com/read/fscgdbvctmqs>`_).
+A latex template (modified from the official ICML template) for **camera-ready papers and extended abstracts** can be found `here <https://www.overleaf.com/read/fscgdbvctmqs>`_).
 
 **Full submissions** consist of:
 

--- a/docs/source/call_for_papers.rst
+++ b/docs/source/call_for_papers.rst
@@ -3,13 +3,13 @@ Call for Submissions
 
 .. note::
 
-  Submissions are now **closed**.
+  Submissions are now **closed**. Please see the updated information below for the camera-ready submission templates.
 
 TL;DR
 ^^^^^
 
-We accept the following submission types:
-Full submissions and extended abstracts (`example <https://drive.google.com/file/d/1bRp0Pp2ek_KbuQILyNPuOgJcUD3EuCR3/view?usp=sharing>`__).
+We accept the following submission types: Full submissions and extended abstracts.
+A latex template (modified from the official ICML template) for **camera ready papers and extended abstracts** can be found `here <https://www.overleaf.com/read/fscgdbvctmqs>`_).
 
 **Full submissions** consist of:
 


### PR DESCRIPTION
Add the link to an overview template for the camera-ready version of extended abstracts and full submissions: https://www.overleaf.com/read/fscgdbvctmqs

Optionally, @EvgeniaAR might want to copy/paste the extended abstract template we hosted previously into the overleaf doc (sent you an invite to the overleaf). Otherwise, I think the current lipsum placeholder text is fine as well.

The main modification to ICML is the conference notice in the lower left corner on the first page.