### PR TITLE
Remove python version in black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
   rev: 22.1.0
   hooks:
   - id: black
-    language_version: python3.8
     additional_dependencies: ['click==8.0.4']
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1


### PR DESCRIPTION
Black currently uses a specification on the python version, does this affect anything/would it be possible to bump this up to any version >3.8? I use 3.10 on my machine.