### PR TITLE
Add global configuration options

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -58,6 +58,15 @@ Task implementations
    :show-inheritance:
    :private-members:
 
+
+Configuration
+-------------
+
+.. automodule:: shifthappens.config
+   :members:
+   :show-inheritance:
+
+
 Accessing Scores for the ImageNet Validation Set
 ________________________________________________
 

--- a/shifthappens/config.py
+++ b/shifthappens/config.py
@@ -1,0 +1,70 @@
+"""Global configuration options for the benchmark."""
+
+import dataclasses
+import os
+
+
+@dataclasses.dataclass(frozen=True)
+class Config:
+    """Global configuration for the benchmark.
+
+    Config options can be edited by the following order:
+    1. By setting variables explicitly when getting the instance via get_config()
+    2. By setting an environment variable, prefixed as "SH_VARIABLE_NAME"
+    3. By relying on the default values defined in this class.
+    """
+
+    __instance = None
+
+    @classmethod
+    def _reset_instance(cls):
+        cls.__instance = None
+
+    @classmethod
+    def _init_instance(cls, **init_kwargs):
+        prefix = "SH_"
+        for field in dataclasses.fields(cls):
+            if field.name in init_kwargs:
+                continue
+            environment_variable_key = prefix + field.name.upper()
+            if environment_variable_key in os.environ:
+                init_kwargs[field.name] = os.environ[environment_variable_key]
+        return cls(**init_kwargs)
+
+    @classmethod
+    def get_instance(cls, **init_kwargs):
+        if cls.__instance is None:
+            cls.__instance = cls._init_instance(**init_kwargs)
+        elif len(init_kwargs) > 0:
+            if cls._init_instance(**init_kwargs) != cls.__instance:
+                raise ValueError(
+                    "Invalid configuration options specified. The global config "
+                    f"was already initialized with values {cls.__instance}, but a "
+                    "second initialization was request with incompatible arguments "
+                    f"{init_kwargs}."
+                )
+        return cls.__instance
+
+    imagenet_validation_path: str = "shifthappens/imagenet"
+    """The imagenet validation path."""
+
+    cache_directory_path: str = "shifthappens/cache"
+    """The caching directory for model results (either absolute or relative to working directory).
+    If the folder does not exist, it will be created."""
+
+    verbose: bool = False
+    """Show additional log messages on stderr (like progress bars)"""
+
+    def __contains__(self, key):
+        return key in self.__dict__
+
+
+def get_config(**init_kwargs):
+    return Config().get_instance(**init_kwargs)
+
+
+def __getattr__(key):
+    config = get_config()
+    if key in config:
+        return getattr(config, key)
+    raise AttributeError(key)

--- a/shifthappens/config.py
+++ b/shifthappens/config.py
@@ -11,12 +11,21 @@ class Config:
     """Global configuration for the benchmark.
 
     Config options can be edited by the following order:
-    1. By setting variables explicitly when getting the instance via get_config()
-    2. By setting an environment variable, prefixed as "SH_VARIABLE_NAME"
-    3. By relying on the default values defined in this class.
+        1. By setting variables explicitly when getting the instance via :py:func:`shifthappens.config.get_config`
+        2. By setting an environment variable, prefixed as "SH_VARIABLE_NAME"
+        3. By relying on the default values defined in this class.
     """
 
     __instance = None
+
+    #:The imagenet validation path.
+    imagenet_validation_path: str = "shifthappens/imagenet"
+
+    #: The caching directory for model results (either absolute or relative to working directory). If the folder does not exist, it will be created.
+    cache_directory_path: str = "shifthappens/cache"
+
+    #: Show additional log messages on stderr (like progress bars).
+    verbose: bool = False
 
     @classmethod
     def _reset_instance(cls):
@@ -36,13 +45,11 @@ class Config:
     @classmethod
     def get_instance(cls, **init_kwargs):
         """
-        Initializes config with provided arguments. If no arguments were provided,
-        config would be initialized with corresponding environment variables if
-        they exist. Otherwise, it will be initialized with default field values
-        defined in :py:class:`Config <shifthappens.config.Config>`.
+        Initializes config with provided arguments. If no arguments are provided,
+        a new config will be initialized.
+
         Args:
-            **init_kwargs: Values for initializing :py:class:`Config <shifthappens.config.Config>`
-         fields.
+            **init_kwargs: Values for initializing :py:class:`Config <shifthappens.config.Config>` fields.
 
         Returns:
             Initialized :py:class:`Config <shifthappens.config.Config>`.
@@ -59,15 +66,6 @@ class Config:
                 )
         return cls.__instance
 
-    #: The imagenet validation path.
-    imagenet_validation_path: str = "shifthappens/imagenet"
-
-    #: The caching directory for model results (either absolute or relative to working directory). If the folder does not exist, it will be created.
-    cache_directory_path: str = "shifthappens/cache"
-
-    #: Show additional log messages on stderr (like progress bars).
-    verbose: bool = False
-
     def __contains__(self, key):
         return key in self.__dict__
 
@@ -78,9 +76,9 @@ def get_config(**init_kwargs) -> Config:
     change defaults paths to ImageNet validation set, cached models result, etc.
     Note that reinitializing config will raise an error.
     For more details see :py:meth:`get_instance <shifthappens.config.Config.get_instance>`.
+
     Args:
-        **init_kwargs: Values for initializing :py:class:`Config <shifthappens.config.Config>`
-        fields.
+        **init_kwargs: Values for initializing :py:class:`Config <shifthappens.config.Config>` fields.
 
     Returns:
         Initialized :py:class:`Config <shifthappens.config.Config>`.

--- a/shifthappens/config.py
+++ b/shifthappens/config.py
@@ -18,7 +18,7 @@ class Config:
 
     __instance = None
 
-    #:The imagenet validation path.
+    #: The imagenet validation path.
     imagenet_validation_path: str = "shifthappens/imagenet"
 
     #: The caching directory for model results (either absolute or relative to working directory). If the folder does not exist, it will be created.

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -116,7 +116,7 @@ def cache_predictions(cls, imagenet_validation_result):
 
     assert (
         shifthappens.config.cache_directory_path is not None
-    ), "Cannot cache model results. shifthappens.config.Config.cache_directory_path is not specified."
+    ), "Cannot cache model results. shifthappens.config.cache_directory_path is not specified."
     save_path = os.path.join(
         shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )
@@ -145,7 +145,7 @@ def is_cached(cls) -> bool:
     """
     assert shifthappens.config.cache_directory_path is not None, (
         "Cannot find cached model results. "
-        "shifthappens.config.Config.cache_directory_path path is not specified. "
+        "shifthappens.config.cache_directory_path path is not specified. "
     )
     load_path = os.path.join(
         shifthappens.config.cache_directory_path, cls.__class__.__name__, ""

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -34,9 +34,10 @@ def _check_imagenet_folder():
 
 def get_imagenet_validation_loader(max_batch_size=128) -> DataLoader:
     """
-    Creates a :py:class:`shifthappens.data.base.DataLoader` for the validation set of ImageNet.
-    Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified.
+    Creates a :py:class:`shifthappens.data.base.DataLoader` for the
+    validation set of ImageNet. Note that the path to ImageNet validation set
+    :py:attr:`shifthappens.config.imagenet_validation_path
+    <shifthappens.config.Config.imagenet_validation_path>` must be specified.
 
     Args:
         max_batch_size: How many samples allowed per batch to load.
@@ -68,9 +69,10 @@ def get_imagenet_validation_loader(max_batch_size=128) -> DataLoader:
 
 def get_cached_predictions(cls) -> dict:
     """
-    Checks whether there exist cached results for the model's class and if so, returns them.
-    Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified.
+    Checks whether there exist cached results for the model's class and if
+    so, returns them. Note that the path to ImageNet validation set
+    :py:attr:`shifthappens.config.imagenet_validation_path
+    <shifthappens.config.Config.imagenet_validation_path>` must be specified.
 
     Args:
         cls: Model's class. Used for specifying folder name.
@@ -103,10 +105,12 @@ def get_cached_predictions(cls) -> dict:
 
 def cache_predictions(cls, imagenet_validation_result):
     """
-    Caches model predictions in cls-named folder and load
-    model predictions from it. Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified as
-    well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
+    Caches model predictions in cls-named folder and load model predictions
+    from it. Note that the path to ImageNet validation set
+    :py:attr:`shifthappens.config.imagenet_validation_path
+    <shifthappens.config.Config.imagenet_validation_path>` must be specified
+    as well as :py:attr:`shifthappens.config.cache_directory_path
+    <shifthappens.config.Config.cache_directory_path>`.
 
     Args:
         cls: Model's class. Used for specifying folder name.
@@ -133,9 +137,12 @@ def cache_predictions(cls, imagenet_validation_result):
 
 def is_cached(cls) -> bool:
     """
-    Checks if model's results are cached in cls-named folder. Note that the path to the ImageNet validation set
-    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified as
-    well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
+    Checks if model's results are cached in cls-named folder. Note that the
+    path to the ImageNet validation set
+    :py:attr:`shifthappens.config.imagenet_validation_path
+    <shifthappens.config.Config.imagenet_validation_path>` must be specified
+    as well as :py:attr:`shifthappens.config.cache_directory_path
+    <shifthappens.config.Config.cache_directory_path>`.
 
     Args:
         cls: Model's class. Used for specifying folder name.

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -1,8 +1,7 @@
 """
 This module provides functionality to access the predictions of a model for the ImageNet validation set.
 Further, the predictions can be cached and loaded from the cache to reduce computational costs.
-Note, that for this to work :py:data:shifthappens.data.imagenet.ImageNetValidationData
-must be set to the ImageNet validation set path. path.
+For path configuration please have a look at :py:module:shifthappens.config.
 """
 import os
 import shutil
@@ -23,22 +22,21 @@ def _check_imagenet_folder():
     """
     assert (
         shifthappens.config.imagenet_validation_path is not None
-    ), "ImagenetValidationData path is not specified."
+    ), "shifthappens.config.ImagenetValidationData path is not specified."
     assert os.path.exists(shifthappens.config.imagenet_validation_path), (
         "You have specified an incorrect path to the ImageNet validation set. "
-        "Files not found at location specified in shithappens.data.imagenet.ImageNetValidationData."
+        "Files not found at location specified in shifthappens.config.imagenet_validation_path."
     )
-
     assert (
-        len(os.listdir(shifthappens.config.imagenet_validation_path)) == 1000
-    ), "ImageNetValidationData folder contains less or more folders than ImageNet classes."
+        len(os.listdir(shifthappens.config.imagenet_validation_path)) >= 1000
+    ), f"{shifthappens.config.imagenet_validation_path} folder contains less folders than ImageNet classes. "
 
 
 def get_imagenet_validation_loader(max_batch_size=128) -> DataLoader:
     """
     Creates a :py:class:`shifthappens.data.base.DataLoader` for the validation set of ImageNet.
     Note that the path to ImageNet validation set
-    :py:data:`shifthappens.data.imagenet.ImageNetValidationData` must be specified.
+    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified.
 
     Args:
         max_batch_size: How many samples allowed per batch to load.
@@ -72,7 +70,7 @@ def get_cached_predictions(cls) -> dict:
     """
     Checks whether there exist cached results for the model's class and if so, returns them.
     Note that the path to ImageNet validation set
-    :py:data:`shifthappens.data.imagenet.ImageNetValidationData` must be specified.
+    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified.
 
     Args:
         cls: Model's class. Used for specifying folder name.
@@ -80,9 +78,10 @@ def get_cached_predictions(cls) -> dict:
     Returns:
         Dictionary of loaded model predictions on ImageNet validation set.
     """
-    assert (
-        shifthappens.config.cache_directory_path is not None
-    ), "Cannot get cached model results. ImageNetValidationPredictionsCache path is not specified."
+    assert shifthappens.config.cache_directory_path is not None, (
+        "Cannot get cached model results. "
+        "shifthappens.config.Config.cache_directory_path is not specified."
+    )
 
     load_path = os.path.join(
         shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
@@ -106,8 +105,8 @@ def cache_predictions(cls, imagenet_validation_result):
     """
     Caches model predictions in cls-named folder and load
     model predictions from it. Note that the path to ImageNet validation set
-    :py:data:`shifthappens.data.imagenet.ImageNetValidationData` must be specified as
-    well as :py:data:`shifthappens.data.imagenet.ImageNetValidationPredictionsCache`.
+    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified as
+    well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
 
     Args:
         cls: Model's class. Used for specifying folder name.
@@ -117,7 +116,7 @@ def cache_predictions(cls, imagenet_validation_result):
 
     assert (
         shifthappens.config.cache_directory_path is not None
-    ), "Cannot cache model results. ImageNetValidationPredictionsCache path is not specified."
+    ), "Cannot cache model results. shifthappens.config.Config.cache_directory_path is not specified."
     save_path = os.path.join(
         shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )
@@ -135,8 +134,8 @@ def cache_predictions(cls, imagenet_validation_result):
 def is_cached(cls) -> bool:
     """
     Checks if model's results are cached in cls-named folder. Note that the path to the ImageNet validation set
-    :py:data:`shifthappens.data.imagenet.ImageNetValidationData` must be specified as
-    well as :py:data:`shifthappens.data.imagenet.ImageNetValidationPredictionsCache`.
+    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified as
+    well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
 
     Args:
         cls: Model's class. Used for specifying folder name.
@@ -146,7 +145,8 @@ def is_cached(cls) -> bool:
     """
     assert (
         shifthappens.config.cache_directory_path is not None
-    ), "Cannot find cached model results. ImageNetValidationPredictionsCache path is not specified."
+    ), "Cannot find cached model results. " \
+       "shifthappens.config.Config.cache_directory_path path is not specified. "
     load_path = os.path.join(
         shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -11,14 +11,9 @@ import numpy as np
 import torchvision.datasets as tv_datasets
 import torchvision.transforms as tv_transforms
 
+import shifthappens.config
 import shifthappens.data.torch as sh_data_torch
 from shifthappens.data.base import DataLoader
-
-#: Must be set to ImageNet validation set path (either absolute or relative to working directory).
-ImageNetValidationData = "shifthappens/imagenet"
-
-#: Must be set to models' results caching directory (either absolute or relative to working directory). If the folder does not exist, it will be created.
-ImageNetValidationPredictionsCache = "shifthappens/cache"
 
 
 def _check_imagenet_folder():
@@ -27,15 +22,15 @@ def _check_imagenet_folder():
     exists and contains a thousand folders (one per class).
     """
     assert (
-        ImageNetValidationData is not None
+        shifthappens.config.imagenet_validation_path is not None
     ), "ImagenetValidationData path is not specified."
-    assert os.path.exists(ImageNetValidationData), (
+    assert os.path.exists(shifthappens.config.imagenet_validation_path), (
         "You have specified an incorrect path to the ImageNet validation set. "
         "Files not found at location specified in shithappens.data.imagenet.ImageNetValidationData."
     )
 
     assert (
-        len(os.listdir(ImageNetValidationData)) == 1000
+        len(os.listdir(shifthappens.config.imagenet_validation_path)) == 1000
     ), "ImageNetValidationData folder contains less or more folders than ImageNet classes."
 
 
@@ -60,7 +55,9 @@ def get_imagenet_validation_loader(max_batch_size=128) -> DataLoader:
     )
     imagenet_val_dataset = sh_data_torch.IndexedTorchDataset(
         sh_data_torch.ImagesOnlyTorchDataset(
-            tv_datasets.ImageFolder(root=ImageNetValidationData, transform=transform)
+            tv_datasets.ImageFolder(
+                root=shifthappens.config.imagenet_validation_path, transform=transform
+            )
         )
     )
 
@@ -84,11 +81,11 @@ def get_cached_predictions(cls) -> dict:
         Dictionary of loaded model predictions on ImageNet validation set.
     """
     assert (
-        ImageNetValidationPredictionsCache is not None
+        shifthappens.config.cache_directory_path is not None
     ), "Cannot get cached model results. ImageNetValidationPredictionsCache path is not specified."
 
     load_path = os.path.join(
-        ImageNetValidationPredictionsCache, cls.__class__.__name__, ""
+        shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )
 
     assert os.path.exists(
@@ -119,10 +116,10 @@ def cache_predictions(cls, imagenet_validation_result):
     """
 
     assert (
-        ImageNetValidationPredictionsCache is not None
+        shifthappens.config.cache_directory_path is not None
     ), "Cannot cache model results. ImageNetValidationPredictionsCache path is not specified."
     save_path = os.path.join(
-        ImageNetValidationPredictionsCache, cls.__class__.__name__, ""
+        shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )
 
     if os.path.exists(save_path):
@@ -148,10 +145,10 @@ def is_cached(cls) -> bool:
         ``True`` if model's results are cached, ``False`` otherwise.
     """
     assert (
-        ImageNetValidationPredictionsCache is not None
+        shifthappens.config.cache_directory_path is not None
     ), "Cannot find cached model results. ImageNetValidationPredictionsCache path is not specified."
     load_path = os.path.join(
-        ImageNetValidationPredictionsCache, cls.__class__.__name__, ""
+        shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )
 
     try:
@@ -167,4 +164,6 @@ def load_imagenet_targets() -> np.ndarray:
     Returns the ground-truth labels of the ImageNet valdation set.
     """
     _check_imagenet_folder()
-    return tv_datasets.ImageFolder(root=ImageNetValidationData).targets
+    return tv_datasets.ImageFolder(
+        root=shifthappens.config.imagenet_validation_path
+    ).targets

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -106,7 +106,7 @@ def cache_predictions(cls, imagenet_validation_result):
     Caches model predictions in cls-named folder and load
     model predictions from it. Note that the path to ImageNet validation set
     :py:attr:`shifthappens.config.imagenet_validation_path` must be specified as
-    well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
+    well as :py:attr:`shifthappens.config.cache_directory_path`.
 
     Args:
         cls: Model's class. Used for specifying folder name.

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -70,7 +70,7 @@ def get_cached_predictions(cls) -> dict:
     """
     Checks whether there exist cached results for the model's class and if so, returns them.
     Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified.
+    :py:attr:`shifthappens.config.imagenet_validation_path` must be specified.
 
     Args:
         cls: Model's class. Used for specifying folder name.

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -80,7 +80,7 @@ def get_cached_predictions(cls) -> dict:
     """
     assert shifthappens.config.cache_directory_path is not None, (
         "Cannot get cached model results. "
-        "shifthappens.config.Config.cache_directory_path is not specified."
+        "shifthappens.config.cache_directory_path is not specified."
     )
 
     load_path = os.path.join(

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -143,10 +143,10 @@ def is_cached(cls) -> bool:
     Returns:
         ``True`` if model's results are cached, ``False`` otherwise.
     """
-    assert (
-        shifthappens.config.cache_directory_path is not None
-    ), "Cannot find cached model results. " \
-       "shifthappens.config.Config.cache_directory_path path is not specified. "
+    assert shifthappens.config.cache_directory_path is not None, (
+        "Cannot find cached model results. "
+        "shifthappens.config.Config.cache_directory_path path is not specified. "
+    )
     load_path = os.path.join(
         shifthappens.config.cache_directory_path, cls.__class__.__name__, ""
     )

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -105,7 +105,7 @@ def cache_predictions(cls, imagenet_validation_result):
     """
     Caches model predictions in cls-named folder and load
     model predictions from it. Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified as
+    :py:attr:`shifthappens.config.imagenet_validation_path` must be specified as
     well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
 
     Args:

--- a/shifthappens/data/imagenet.py
+++ b/shifthappens/data/imagenet.py
@@ -70,7 +70,7 @@ def get_cached_predictions(cls) -> dict:
     """
     Checks whether there exist cached results for the model's class and if so, returns them.
     Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.imagenet_validation_path` must be specified.
+    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified.
 
     Args:
         cls: Model's class. Used for specifying folder name.
@@ -105,8 +105,8 @@ def cache_predictions(cls, imagenet_validation_result):
     """
     Caches model predictions in cls-named folder and load
     model predictions from it. Note that the path to ImageNet validation set
-    :py:attr:`shifthappens.config.imagenet_validation_path` must be specified as
-    well as :py:attr:`shifthappens.config.cache_directory_path`.
+    :py:attr:`shifthappens.config.Config.imagenet_validation_path` must be specified as
+    well as :py:attr:`shifthappens.config.Config.cache_directory_path`.
 
     Args:
         cls: Model's class. Used for specifying folder name.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+
+import shifthappens.config
+
+
+def reset_instance():
+    """Reset the singleton instance at the start of each test."""
+    shifthappens.config.Config._reset_instance()
+
+
+def test_init_config():
+    reset_instance()
+    cfg = shifthappens.config.get_config()
+    assert cfg is not None
+    assert isinstance(cfg, shifthappens.config.Config)
+
+
+def test_env_config():
+    reset_instance()
+    os.environ["SH_CACHE_DIRECTORY_PATH"] = "/tmp"
+    cfg = shifthappens.config.get_config()
+    assert cfg.cache_directory_path == "/tmp"
+
+
+def test_default_args_config():
+    reset_instance()
+    os.environ["SH_CACHE_DIRECTORY_PATH"] = "/set_by_env"
+    cfg = shifthappens.config.get_config(cache_directory_path="/set_by_arg")
+    assert cfg.cache_directory_path == "/set_by_arg"
+
+
+def test_default_args_wrong_override_config():
+    reset_instance()
+    os.environ["SH_CACHE_DIRECTORY_PATH"] = "/set_by_env"
+    cfg = shifthappens.config.get_config()
+    assert cfg.cache_directory_path == "/set_by_env"
+
+    # get config again with correct arg is fine
+    cfg = shifthappens.config.get_config(cache_directory_path="/set_by_env")
+    assert cfg.cache_directory_path == "/set_by_env"
+
+    # get config with different arg will throw an error
+    with pytest.raises(ValueError):
+        cfg = shifthappens.config.get_config(cache_directory_path="/set_by_arg")
+
+
+def test_retrieve_directly():
+    reset_instance()
+    cfg = shifthappens.config.get_config()
+    shifthappens.config.cache_directory_path == cfg.cache_directory_path


### PR DESCRIPTION
A proposal for adding global configuration options. Right now I only saw three locations where this might be handy; in the future we might build this out to some hierachical structure where each package gets its own config, but my sense is that this is currently overkill.

The PR adds tests directly that should demonstrate the usecases. In brief, the functionality can be used by simply using

```python
import shifthappens.config
shifthappens.config.verbose
shifthappens.config.imagenet_validation_path
```

etc.

In case this looks good, an option task before ready to merge is to fix the docs and properly document how to extend the config, which might be useful for the other contributors as well.

Fix #55 