### PR TITLE
removed double info

### DIFF
--- a/docs/source/speakers.html
+++ b/docs/source/speakers.html
@@ -36,4 +36,3 @@
     </div>
 </div>
 <hr>
-<p>More speakers will be announced soon!</p>

--- a/docs/source/speakers.html
+++ b/docs/source/speakers.html
@@ -3,7 +3,7 @@
         <hr>
         <img style="float: left; margin-right: 20px; max-width: 200px;" alt="Aleksander Madry" src="_static/speakers/aleksander_madry.png">
         <p>
-            <a class="reference external" href="https://people.csail.mit.edu/madry/">Aleksander Mądry</a>  is the Cadence Design Systems Professor of Computing at MIT, leads the MIT Center for Deployable Machine Learning as well as is a faculty co-lead for the MIT AI Policy Forum. His research interests span algorithms, continuous optimization, and understanding machine learning from a robustness and deployability perspectives. is the Cadence Design Systems Professor of Computing at MIT, leads the MIT Center for Deployable Machine Learning as well as is a faculty co-lead for the MIT AI Policy Forum. His research interests span algorithms, continuous optimization, and understanding machine learning from a robustness and deployability perspectives.
+            <a class="reference external" href="https://people.csail.mit.edu/madry/">Aleksander Mądry</a>  is the Cadence Design Systems Professor of Computing at MIT, leads the MIT Center for Deployable Machine Learning as well as is a faculty co-lead for the MIT AI Policy Forum. His research interests span algorithms, continuous optimization, and understanding machine learning from a robustness and deployability perspectives.
         </p>
     </div>
     <div>


### PR DESCRIPTION
In Aleksander Mądry's info, the text was printed twice. This PR fixes that.