### PR TITLE
Update PR status workflow

### DIFF
--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -45,7 +45,7 @@ jobs:
     - name: documentation
       id: documentation
       run: |
-        RESULT=$(git diff --name-only origin/main | grep .py$ | xargs interrogate -f 0 -v)
+        RESULT=$(git diff --name-only origin/main | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
         RESULT=$(tail -n +3 <<< $RESULT)
         STATUS=$(tail -n1 <<< $RESULT)
         STATUS=$(sed 's/-//g' <<< $STATUS)


### PR DESCRIPTION
The current PR status will fail if a file present in `main` was removed in the local PR. For example,

```
git diff --name-only origin/main | grep .py$ | xargs interrogate -f 0 -v 
Usage: interrogate [OPTIONS] [PATHS]...

Error: Invalid value for '[PATHS]...': Path '<path to removed file>' does not exist.
```

A simple check is to filter all filesnames with `ls` and drop the error messages of the `ls` call:

```
git diff --name-only origin/main | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v
```

