### PR TITLE
Fix action for posting PR status

### DIFF
--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -58,7 +58,7 @@ jobs:
         STATUS=$(echo $STATUS | xargs echo -n)
         RESULT=$(head -n -1 <<< $RESULT)
         # Escape underscores such that they are correctly rendered in markdown.
-        # RESULT=$(echo $RESULT | tr '_' '\_')
+        RESULT=$(echo $RESULT | sed 's/_/\\_/g')
         # remove second to last line
         RESULTA=$(head -n -2 <<< $RESULT)
         RESULTB=$(tail -n1 <<< $RESULT)

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -57,14 +57,14 @@ jobs:
         # trim
         STATUS=$(echo $STATUS | xargs echo -n)
         RESULT=$(head -n -1 <<< $RESULT)
-        # Escape underscores such that they are correctly rendered in markdown.
-        RESULT=$(echo $RESULT | sed 's/_/\\_/g')
         # remove second to last line
         RESULTA=$(head -n -2 <<< $RESULT)
         RESULTB=$(tail -n1 <<< $RESULT)
         NL=$'\n'
         RESULT="$RESULTA${NL}||||||${NL}$RESULTB"
         RESULT="$RESULT${NL}${NL}$STATUS"
+        # Escape underscores such that they are correctly rendered in markdown.
+        RESULT=$(sed 's/_/\\_/g' <<< $RESULT)
         RESULT="${RESULT//'%'/'%25'}"
         RESULT="${RESULT//$'\n'/'%0A'}"
         RESULT="${RESULT//$'\r'/'%0D'}"

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -1,8 +1,9 @@
 name: PR Status
 
 # Controls when the workflow will run
+# was pull_request_target
 on:
-  pull_request_target:
+  pull_request:
     branches:    
       - main
     

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -58,7 +58,7 @@ jobs:
         STATUS=$(echo $STATUS | xargs echo -n)
         RESULT=$(head -n -1 <<< $RESULT)
         # Escape underscores such that they are correctly rendered in markdown.
-        RESULT=$(echo $RESULT | tr '_' '\_')
+        # RESULT=$(echo $RESULT | tr '_' '\_')
         # remove second to last line
         RESULTA=$(head -n -2 <<< $RESULT)
         RESULTB=$(tail -n1 <<< $RESULT)

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -1,9 +1,8 @@
 name: PR Status
 
 # Controls when the workflow will run
-# was pull_request_target
 on:
-  pull_request:
+  pull_request_target:
     branches:    
       - main
     

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -50,13 +50,15 @@ jobs:
     - name: documentation
       id: documentation
       run: |
-        RESULT=$(tr ${{ steps.files.outputs.added_modified }} ',' '\n' | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
+        RESULT=$(echo ${{ steps.files.outputs.added_modified }} | tr ',' '\n' | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
         RESULT=$(tail -n +3 <<< $RESULT)
         STATUS=$(tail -n1 <<< $RESULT)
         STATUS=$(sed 's/-//g' <<< $STATUS)
         # trim
         STATUS=$(echo $STATUS | xargs echo -n)
         RESULT=$(head -n -1 <<< $RESULT)
+        # Escape underscores such that they are correctly rendered in markdown.
+        RESULT=$(echo $RESULT | tr '_' '\_')
         # remove second to last line
         RESULTA=$(head -n -2 <<< $RESULT)
         RESULTB=$(tail -n1 <<< $RESULT)

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -50,7 +50,7 @@ jobs:
     - name: documentation
       id: documentation
       run: |
-        RESULT=$(${{ steps.files.outputs.added_modified }} | tr ',' '\n' | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
+        RESULT=$(tr ${{ steps.files.outputs.added_modified }} ',' '\n' | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
         RESULT=$(tail -n +3 <<< $RESULT)
         STATUS=$(tail -n1 <<< $RESULT)
         STATUS=$(sed 's/-//g' <<< $STATUS)

--- a/.github/workflows/pr-status.yml
+++ b/.github/workflows/pr-status.yml
@@ -42,10 +42,14 @@ jobs:
         }
         python -m pip install --upgrade pip setuptools wheel
         retry-with-backoff pip install -r requirements_dev.txt
+    - id: files
+      uses: jitterbit/get-changed-files@v1
+      with:
+        format: 'csv'
     - name: documentation
       id: documentation
       run: |
-        RESULT=$(git diff --name-only origin/main | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
+        RESULT=$(${{ steps.files.outputs.added_modified }} | tr ',' '\n' | grep .py$ | xargs ls 2>/dev/null | xargs interrogate -f 0 -v)
         RESULT=$(tail -n +3 <<< $RESULT)
         STATUS=$(tail -n1 <<< $RESULT)
         STATUS=$(sed 's/-//g' <<< $STATUS)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+import shutil
+
+print(shutil.get_terminal_size())


### PR DESCRIPTION
- Previously the action also posted the status of files that were added in the main branch after the current PR's branch was created.
- Also, underscores were not correctly treated when posting the status on GitHub.